### PR TITLE
Added a simple pomodoro widget

### DIFF
--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -14,6 +14,8 @@ separator=false
 markup=none
 
 #simple pomodoro status
+#to use simply do "pomodoro start <task ie 'reversing the mainframe'>"
+#you might wanna add pomodoro to your patha
 [pomodoro]
 command=/home/kali/go/bin/pomodoro status --format "%d 🍅 %!r 🍅 Collected today : %c"
 label=Task:

--- a/.config/i3/i3blocks.conf
+++ b/.config/i3/i3blocks.conf
@@ -13,6 +13,12 @@ separator_block_width=30
 separator=false
 markup=none
 
+#simple pomodoro status
+[pomodoro]
+command=/home/kali/go/bin/pomodoro status --format "%d 🍅 %!r 🍅 Collected today : %c"
+label=Task:
+interval=1
+
 # CPU usage
 #
 # The script may be called with -w and -c switches to specify thresholds,

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,9 @@ sudo apt update && sudo apt upgrade -y
 
 sudo apt-get install -y arandr flameshot arc-theme feh i3blocks i3status i3 i3-wm lxappearance python3-pip rofi unclutter cargo compton papirus-icon-theme imagemagick
 sudo apt-get install -y libxcb-shape0-dev libxcb-keysyms1-dev libpango1.0-dev libxcb-util0-dev xcb libxcb1-dev libxcb-icccm4-dev libyajl-dev libev-dev libxcb-xkb-dev libxcb-cursor-dev libxkbcommon-dev libxcb-xinerama0-dev libxkbcommon-x11-dev libstartup-notification0-dev libxcb-randr0-dev libxcb-xrm0 libxcb-xrm-dev autoconf meson
-sudo apt-get install -y libxcb-render-util0-dev libxcb-shape0-dev libxcb-xfixes0-dev 
+sudo apt-get install -y libxcb-render-util0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+sudo apt-get install -y golang
+go install github.com/open-pomodoro/openpomodoro-cli/cmd/pomodoro@latest
 
 mkdir -p ~/.local/share/fonts/
 


### PR DESCRIPTION

Summary:
I use the pomodoro technique for studying and I find it quite useful, so I attempted to port it's functionality to this config, I did the following:
1-added an i3blocks.conf widget utilizing open-pomodoro/openpomodoro-cli.
2-edited install.sh to install go and build the latest release of said program.
![image](https://user-images.githubusercontent.com/34142795/225866816-852d7e4c-e212-4d4c-b885-cf2db7359c47.png)

Explanation:
The Pomodoro technique is a time management method that helps people work more efficiently and productively by breaking tasks into shorter, focused work intervals, typically 25 minutes in length, separated by short breaks.

By using the Pomodoro technique, people can better manage their time, minimize distractions, and improve their focus on tasks. This technique can help reduce procrastination and improve motivation, as people see progress made on their tasks in short, manageable intervals.

The most elegant solution I found to integrate pom into i3 was by adding it as a bar widget, and I feel it plays nicely with the other components in the config.

Todo's and limitations : 
1- Add mouse support [to stop or start the pom sessions]
2- notifications support
